### PR TITLE
Double wrapping cost fix

### DIFF
--- a/payu/payu.php
+++ b/payu/payu.php
@@ -895,7 +895,7 @@ class PayU extends PaymentModule
             $grand_total = $total;
             return $grand_total;
         } else {
-            $grand_total = $this->toAmount($this->cart->getOrderTotal(true, Cart::BOTH)) + $wrapping_fees_tax_inc;
+            $grand_total = $this->toAmount($this->cart->getOrderTotal(true, Cart::BOTH));
             return $grand_total;
         }
     }


### PR DESCRIPTION
Method Cart::getOrderTotal(true, Cart::BOTH) in PS1.6 returns cart total with wrapping cost.