### PR TITLE
Fix IE11 issue

### DIFF
--- a/payu/js/payu.js
+++ b/payu/js/payu.js
@@ -2,6 +2,7 @@ $(document).ready(function () {
     $('.payMethodEnable .payMethodLabel').click(function () {
         $('.payMethod').removeClass('payMethodActive');
         $(this).closest('.payMethod').addClass('payMethodActive');
+        $(this).prev().prop('checked', true);
     });
 
     $('#HOOK_PAYMENT').on('click', 'a.payu', function () {


### PR DESCRIPTION
On IE11 if you click on an image, the related input is not checked. The fix makes sure that the input is checked if a method is chosen